### PR TITLE
Explicitly require CGI standard library

### DIFF
--- a/lib/urn.rb
+++ b/lib/urn.rb
@@ -1,3 +1,5 @@
+require 'cgi'
+
 class URN
   PATTERN = 'urn:(?!urn:)[a-z0-9\-]{1,31}:[\S]+'.freeze
   REGEX = /^#{PATTERN}$/i


### PR DESCRIPTION
When running the specs or using this library inside a Rails application, the CGI standard library will be automatically loaded.

If running without any dependencies, attempting to normalize a URN will fail with "uninitialized constant URN::CGI".
