### PR TITLE
Use RSpec's default configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@
 /doc/
 /pkg/
 /spec/reports/
+/spec/examples.txt
 /tmp/

--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,2 @@
---format documentation
 --color
+--require spec_helper

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,18 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
-require 'urn'
+RSpec.configure do |config|
+  config.filter_run :focus
+  config.run_all_when_everything_filtered = true
+  config.example_status_persistence_file_path = "spec/examples.txt"
+  config.disable_monkey_patching!
+  config.warnings = true
+  config.order = :random
+  config.default_formatter = 'doc' if config.files_to_run.one?
+  Kernel.srand config.seed
+
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+end

--- a/spec/urn_spec.rb
+++ b/spec/urn_spec.rb
@@ -1,24 +1,24 @@
-require 'spec_helper'
+require 'urn'
 
-describe URN do
+RSpec.describe URN do
   describe '#valid?' do
     context 'returns true' do
       it 'if it is valid' do
-        expect(described_class.new('urn:namespace:specificstring').valid?).to be(true)
+        expect(described_class.new('urn:namespace:specificstring')).to be_valid
       end
 
       it 'if namespace includes urn' do
-        expect(described_class.new('urn:urnnamespace:specificstring').valid?).to be(true)
+        expect(described_class.new('urn:urnnamespace:specificstring')).to be_valid
       end
     end
 
     context 'returns false' do
       it 'if it does not start with urn' do
-        expect(described_class.new('not-urn:namespace:specificstring').valid?).to be(false)
+        expect(described_class.new('not-urn:namespace:specificstring')).not_to be_valid
       end
 
       it 'if namespace is urn' do
-        expect(described_class.new('urn:urn:specificstring').valid?).to be(false)
+        expect(described_class.new('urn:urn:specificstring')).not_to be_valid
       end
     end
   end


### PR DESCRIPTION
Generated with `rspec --init`, use RSpec's default configuration which disables monkey-patching (requiring the use of `RSpec.describe` rather than `describe`) and runs examples in a random order.

Update expectation matchers to use `be_valid` to check the truthiness of `valid?` rather comparing the output to `true` and `false` directly.
