### PR TITLE
Simplify gemspec

### DIFF
--- a/urn.gemspec
+++ b/urn.gemspec
@@ -1,22 +1,18 @@
-# coding: utf-8
-
 Gem::Specification.new do |spec|
   spec.name          = 'urn'
   spec.version       = '0.1.2'
   spec.authors       = ['Ana Castro', 'Jonathan Hernandez']
-  spec.email         = ['support@altmetric.com']
+  spec.email         = 'support@altmetric.com'
 
   spec.summary       = 'Utility methods to normalize and validate URNs'
-  spec.description   = ''
-  spec.homepage      = 'http://github.com/altmetric/urn'
+  spec.homepage      = 'https://github.com/altmetric/urn'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = Dir['*.{md,txt}', 'lib/**/*.rb']
+  spec.test_files    = Dir['spec/**/*.rb']
   spec.bindir        = 'exe'
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.10'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec'
+  spec.add_development_dependency('bundler', '~> 1.10')
+  spec.add_development_dependency('rake', '~> 10.0')
+  spec.add_development_dependency('rspec', '~> 3.4')
 end


### PR DESCRIPTION
Use Ruby's standard library `Dir` globbing for finding files in the gemspec rather than shelling out to `git` which is considerably more expensive (and requires `git` to be present).
