### PR TITLE
Use stricter, RFC 2141 compliant regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ Ruby library to validate and normalize URNs.
 **Current version:** 0.1.2  
 **Supported Ruby versions:** 1.8.7, 1.9.2, 1.9.3, 2.0, 2.1, 2.2, 2.3
 
-Note: This gem doesn't strictly follow [RFC 2141](https://www.ietf.org/rfc/rfc2141.txt)
-
 ## Installation
 
 Add this line to your application's `Gemfile`:
@@ -66,13 +64,7 @@ URN.new('urn:foo:bar').valid?
 #=> true
 ```
 
-Returns true if the `URN` is valid according to the following rules:
-
-* Begins with `urn:` (case-insensitive);
-* Contains a namespace identifier consisting solely of letters, numbers or
-  hyphens and is not the string `urn`;
-* Contains a namespace specific string consisting of any non-whitespace
-  character.
+Returns true if the `URN` is valid according to [RFC 2141](https://www.ietf.org/rfc/rfc2141.txt).
 
 ### `URN#normalize`
 

--- a/lib/urn.rb
+++ b/lib/urn.rb
@@ -1,5 +1,6 @@
 class URN
-  PATTERN = 'urn:(?!urn:)[a-z0-9\-]{1,31}:[\S]+'.freeze
+  PATTERN = %(urn:(?!urn:)[A-Za-z0-9][A-Za-z0-9\-]{1,31}:) +
+            %((?:[A-Za-z0-9()+,-.:=@;$_!*']|%[0-9A-Fa-f]{2})+).freeze
   REGEX = /^#{PATTERN}$/i
 
   attr_reader :urn

--- a/lib/urn.rb
+++ b/lib/urn.rb
@@ -1,7 +1,7 @@
 class URN
-  PATTERN = %(urn:(?!urn:)[A-Za-z0-9][A-Za-z0-9\-]{1,31}:) +
-            %((?:[A-Za-z0-9()+,-.:=@;$_!*']|%[0-9A-Fa-f]{2})+).freeze
-  REGEX = /^#{PATTERN}$/i
+  PATTERN = %{(?i:urn:(?!urn:)[a-z0-9][a-z0-9\-]{1,31}:} +
+            %{(?:[a-z0-9()+,-.:=@;$_!*']|%[0-9a-f]{2})+)}.freeze
+  REGEX = /\A#{PATTERN}\z/
 
   attr_reader :urn
   private :urn

--- a/spec/urn_spec.rb
+++ b/spec/urn_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'urn'
 
 RSpec.describe URN do
@@ -17,6 +18,24 @@ RSpec.describe URN do
     it 'returns false if namespace is urn' do
       expect(described_class.new('urn:urn:specificstring')).not_to be_valid
     end
+
+    it 'returns true if the namespace identifier is 32 characters long' do
+      nid = 'a' * 32
+
+      expect(described_class.new("urn:#{nid}:bar")).to be_valid
+    end
+
+    it 'returns false if the namespace identifier begins with a hyphen' do
+      expect(described_class.new('urn:-foo:bar')).not_to be_valid
+    end
+
+    it 'returns false if the namespace specific string has invalid escaping' do
+      expect(described_class.new('urn:foo:bar%2')).not_to be_valid
+    end
+
+    it 'returns false if the namespace specific string has reserved characters' do
+      expect(described_class.new('urn:foo:café')).not_to be_valid
+    end
   end
 
   describe '#normalize' do
@@ -28,15 +47,15 @@ RSpec.describe URN do
       expect(described_class.new('URN:foo:123').normalize).to eq('urn:foo:123')
     end
 
-    it 'lowercases the NID' do
+    it 'lowercases the namespace identifier' do
       expect(described_class.new('urn:FOO:123').normalize).to eq('urn:foo:123')
     end
 
-    it 'lowercases %-escaping in the NSS' do
+    it 'lowercases %-escaping in the namespace specific string' do
       expect(described_class.new('urn:foo:123%2C456').normalize).to eq('urn:foo:123%2c456')
     end
 
-    it 'does not lowercase other characters in the NSS' do
+    it 'does not lowercase other characters in the namespace specific string' do
       expect(described_class.new('urn:foo:BA%2CR').normalize).to eq('urn:foo:BA%2cR')
     end
   end

--- a/spec/urn_spec.rb
+++ b/spec/urn_spec.rb
@@ -19,6 +19,10 @@ RSpec.describe URN do
       expect(described_class.new('urn:urn:specificstring')).not_to be_valid
     end
 
+    it 'returns false if namespace is URN' do
+      expect(described_class.new('urn:URN:specificstring')).not_to be_valid
+    end
+
     it 'returns true if the namespace identifier is 32 characters long' do
       nid = 'a' * 32
 


### PR DESCRIPTION
GitHub: https://github.com/altmetric/urn/issues/2

Be stricter with URN validation: specifically matching URNs compliant with RFC 2141:
- Starting with "urn:"
- Containing a namespace identifier that is not "urn", starting with an alphanumeric character followed by up to 31 alphanumeric or hyphen characters
- Containing a namespace specific string of permitted characters and -escaping

Note this will reject any URNs that are not %-escaped.

This does not alter the API or use the regular expression to extract the namespace identifier and namespace specific string.
