### PR TITLE
Getters for NID and NSS

### DIFF
--- a/lib/urn.rb
+++ b/lib/urn.rb
@@ -14,13 +14,35 @@ class URN
     !(urn =~ REGEX).nil?
   end
 
+  def nid
+    return unless valid?
+
+    _scheme, nid, _nss = parse
+
+    nid
+  end
+
+  def nss
+    return unless valid?
+
+    _scheme, _nid, nss = parse
+
+    nss
+  end
+
   def normalize
     return unless valid?
 
-    _scheme, nid, nss = urn.split(':', 3)
+    _scheme, nid, nss = parse
     normalized_nid = nid.downcase
-    normalized_nss = nss.gsub(/%([0-9a-f]{2})/i) { |hex| hex.downcase }
+    normalized_nss = nss.gsub(/%([0-9a-f]{2})/i, &:downcase)
 
     "urn:#{normalized_nid}:#{normalized_nss}"
+  end
+
+  private
+
+  def parse
+    urn.split(':', 3)
   end
 end

--- a/spec/urn_spec.rb
+++ b/spec/urn_spec.rb
@@ -63,4 +63,24 @@ RSpec.describe URN do
       expect(described_class.new('urn:foo:BA%2CR').normalize).to eq('urn:foo:BA%2cR')
     end
   end
+
+  describe '#nid' do
+    it 'returns the namespace identifier' do
+      expect(described_class.new('urn:namespace:specificstring').nid).to eq('namespace')
+    end
+
+    it 'returns nil if it is not valid' do
+      expect(described_class.new('urn:urn:specificstring').nid).to be_nil
+    end
+  end
+
+  describe '#nss' do
+    it 'returns the namespace specific string' do
+      expect(described_class.new('urn:namespace:specificstring').nss).to eq('specificstring')
+    end
+
+    it 'returns nil if it is not valid' do
+      expect(described_class.new('urn:namespace:café').nss).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Github: #2

Returns the namespace identifier (for `.nid`) and the namespace specific string (for `.nss`).
Returns nil if the `URN` is not valid.

``` ruby
urn = URN.new('urn:nid:nss')
#=> #<URN:0x007ffb989947b0 @urn="urn:nid:nss">
urn.nid
#=> "nid"
urn.nss
#=> "nss"

urn = URN.new('not_valid')
#=> #<URN:0x007ffb99099b50 @urn="not_valid">
urn.nid
#=> nil
urn.nss
#=> nil
```
