### PR TITLE
Validity check at object creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
+## Current
+### Changed
+- Only return `URN` instances for valid `URN`s at creation. Raise `URN::InvalidURNError` otherwise.
+- `#valid?` is deprecated and always return true
+
+## Added
+- Shortcut method (`URN()`) at creation:
+```ruby
+urn = URN('URN:NameSpace:Identifier')
+#=> #<URN:0x007fd97a835558 @urn="URN:NameSpace:Identifier">
+```
+- `REGEX` into the API documentation
+
 ## [1.0.0] - 2016-03-09
 ### Changed
 - The library is now [RFC2141](https://www.ietf.org/rfc/rfc2141.txt) compliant.

--- a/README.md
+++ b/README.md
@@ -25,14 +25,17 @@ Or install it yourself as:
 ## Usage
 
 ```ruby
+urn = URN('URN:NameSpace:Identifier')
+#=> #<URN:0x007fd97a835558 @urn="URN:NameSpace:Identifier">
+
 urn = URN.new('URN:NameSpace:Identifier')
 #=> #<URN:0x007fd97a835558 @urn="URN:NameSpace:Identifier">
 
-urn.valid?
-#=> true
-
 urn.normalize
 #=> "urn:namespace:Identifier"
+
+urn = URN('123')
+#=> URN::InvalidURNError: bad URN(is not URN?): 123
 ```
 
 ## API Documentation
@@ -46,26 +49,29 @@ text.match(/\?urn=(#{URN::PATTERN})/)
 Return a `String` of an unanchored regular expression suitable for matching
 URNs.
 
-### `URN.new`
+### `URN::REGEX`
 
 ```ruby
+URN::REGEX
+#=> /\A(?i:urn:(?!urn:)[a-z0-9][a-z0-9-]{1,31}:(?:[a-z0-9()+,-.:=@;$_!*']|%[0-9a-f]{2})+)\z/
+```
+
+Return an `Regexp` object with the anchored regular expression suitable to match a URN.
+
+### `URN()` or `URN.new`
+
+```ruby
+urn = URN('urn:nid:nss')
+#=> #<URN:0xdecafbad @urn="urn:nid:nss">
+
 urn = URN.new('urn:nid:nss')
 #=> #<URN:0xdecafbad @urn="urn:nid:nss">
+
+urn = URN.new('1234')
+#=> URN::InvalidURNError: bad URN(is not URN?): 1234
 ```
 
-Return a new `URN` instance with the given string.
-
-### `URN#valid?`
-
-```ruby
-URN.new('foo').valid?
-#=> false
-
-URN.new('urn:foo:bar').valid?
-#=> true
-```
-
-Returns true if the `URN` is valid according to [RFC 2141](https://www.ietf.org/rfc/rfc2141.txt).
+Return a new `URN` instance when the given string is valid according to [RFC 2141](https://www.ietf.org/rfc/rfc2141.txt). Otherwise, it raises an `URN::InvalidURNError`
 
 ### `URN#normalize`
 

--- a/lib/urn.rb
+++ b/lib/urn.rb
@@ -1,4 +1,10 @@
+def URN(urn)
+  URN.new(urn)
+end
+
 class URN
+  InvalidURNError = Class.new(StandardError)
+
   PATTERN = %{(?i:urn:(?!urn:)[a-z0-9][a-z0-9\-]{1,31}:} +
             %{(?:[a-z0-9()+,-.:=@;$_!*']|%[0-9a-f]{2})+)}.freeze
   REGEX = /\A#{PATTERN}\z/
@@ -7,19 +13,20 @@ class URN
   private :urn
 
   def initialize(urn)
+    fail(InvalidURNError, "bad URN(is not URN?): #{urn}") if urn !~ REGEX
+
     @urn = urn
   end
 
   def valid?
-    !(urn =~ REGEX).nil?
+    warn "[DEPRECATION] `valid?` is deprecated. Validity check is now at object creation."
+    true
   end
 
   def normalize
-    return unless valid?
-
     _scheme, nid, nss = urn.split(':', 3)
     normalized_nid = nid.downcase
-    normalized_nss = nss.gsub(/%([0-9a-f]{2})/i) { |hex| hex.downcase }
+    normalized_nss = nss.gsub(/%([0-9a-f]{2})/i, &:downcase)
 
     "urn:#{normalized_nid}:#{normalized_nss}"
   end

--- a/spec/urn_spec.rb
+++ b/spec/urn_spec.rb
@@ -2,51 +2,61 @@
 require 'urn'
 
 RSpec.describe URN do
-  describe '#valid?' do
-    it 'returns true if it is valid' do
-      expect(described_class.new('urn:namespace:specificstring')).to be_valid
+  describe 'Kernel.URN' do
+    it 'returns a URN if it is valid' do
+      expect(URN('urn:namespace:specificstring')).to be_kind_of(described_class)
     end
 
-    it 'returns true if namespace includes urn' do
-      expect(described_class.new('urn:urnnamespace:specificstring')).to be_valid
+    it 'raise InvalidURNError if it is not valid' do
+      expect { URN('urn:urn:1234') }.to raise_error(described_class::InvalidURNError, 'bad URN(is not URN?): urn:urn:1234')
+    end
+  end
+
+  describe '#initialize' do
+    it 'returns a URN if it is valid' do
+      expect(described_class.new('urn:namespace:specificstring')).to be_kind_of(described_class)
     end
 
-    it 'returns false if it does not start with urn' do
-      expect(described_class.new('not-urn:namespace:specificstring')).not_to be_valid
+    it 'raise InvalidURNError if it is not valid' do
+      expect { described_class.new('urn:urn:1234') }.to raise_error(described_class::InvalidURNError, 'bad URN(is not URN?): urn:urn:1234')
     end
 
-    it 'returns false if namespace is urn' do
-      expect(described_class.new('urn:urn:specificstring')).not_to be_valid
+    it 'returns a URN if namespace includes urn' do
+      expect(described_class.new('urn:urnnamespace:specificstring')).to be_kind_of(described_class)
     end
 
-    it 'returns false if namespace is URN' do
-      expect(described_class.new('urn:URN:specificstring')).not_to be_valid
+    it 'returns error if it does not start with urn' do
+      expect { described_class.new('not-urn:namespace:specificstring') }.to raise_error(described_class::InvalidURNError)
+    end
+
+    it 'returns error if namespace is urn' do
+      expect { described_class.new('urn:urn:specificstring') }.to raise_error(described_class::InvalidURNError)
+    end
+
+    it 'returns error if namespace is URN' do
+      expect { described_class.new('urn:URN:specificstring') }.to raise_error(described_class::InvalidURNError)
     end
 
     it 'returns true if the namespace identifier is 32 characters long' do
       nid = 'a' * 32
 
-      expect(described_class.new("urn:#{nid}:bar")).to be_valid
+      expect(described_class.new("urn:#{nid}:bar")).to be_kind_of(described_class)
     end
 
-    it 'returns false if the namespace identifier begins with a hyphen' do
-      expect(described_class.new('urn:-foo:bar')).not_to be_valid
+    it 'returns error if the namespace identifier begins with a hyphen' do
+      expect { described_class.new('urn:-foo:bar') }.to raise_error(described_class::InvalidURNError)
     end
 
-    it 'returns false if the namespace specific string has invalid escaping' do
-      expect(described_class.new('urn:foo:bar%2')).not_to be_valid
+    it 'returns error if the namespace specific string has invalid escaping' do
+      expect { described_class.new('urn:foo:bar%2') }.to raise_error(described_class::InvalidURNError)
     end
 
-    it 'returns false if the namespace specific string has reserved characters' do
-      expect(described_class.new('urn:foo:café')).not_to be_valid
+    it 'returns error if the namespace specific string has reserved characters' do
+      expect { described_class.new('urn:foo:café') }.to raise_error(described_class::InvalidURNError)
     end
   end
 
   describe '#normalize' do
-    it 'returns nil if it is not valid' do
-      expect(described_class.new('urn:').normalize).to be_nil
-    end
-
     it 'lowercases the leading "urn:" token' do
       expect(described_class.new('URN:foo:123').normalize).to eq('urn:foo:123')
     end


### PR DESCRIPTION
- Added shortcut method (`URN()`) at creation.

``` ruby
urn = URN('URN:NameSpace:Identifier')
#=> #<URN:0x007fd97a835558 @urn="URN:NameSpace:Identifier">
```
- Only return `URN` instances for valid `URN`s at creation. Raise `URN::InvalidURNError` otherwise.

``` ruby
urn = URN('123')
#=> URN::InvalidURNError: bad URN(is not URN?): 123
```
- `#valid?` is deprecated and always return true.
- Added `REGEX` into the API documentation

**Note: This merges against the 2.0 feature branch**
