### PR TITLE
Release 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ URN('URN:Name:Spec').nss
 URN('URN:Name:Spec').to_s
 #=> "URN:Name:Spec"
 ```
+- `#===(other)` returns true if the URN objects are equivalent. This method normalizes both URNs before doing the comparison, and allows comparison against Strings.
+- `#==(other)` returns true if the URN objects are equivalent. This method normalizes both URNs before doing the comparison.
+- `#eql?(other)` returns true if the URN objects are equal. This method does NOT normalize either URN before doing the comparison.
 
 ## [1.0.0] - 2016-03-09
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Only return `URN` instances for valid `URN`s at creation. Raise `URN::InvalidURNError` otherwise.
 - `#normalize` returns a normalized `URN` object instead of its `String` representation. You can get the normalized `String` representation with `.normalize.to_s`
+- Do not allow hexadecimal numbers from 0 to 20. See [RFC2141](https://www.ietf.org/rfc/rfc2141.txt) section "2.4 Excluded characters".
 
 ### Added
 - Shortcut method (`URN()`) at creation:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,19 +10,19 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ## Added
 - Shortcut method (`URN()`) at creation:
 ```ruby
-urn = URN('URN:NameSpace:Identifier')
-#=> #<URN:0x007fd97a835558 @urn="URN:NameSpace:Identifier">
+urn = URN('URN:Name:Spec')
+#=> #<URN:0x007fd97a835558 @urn="URN:Name:Spec">
 ```
 - `REGEX` into the API documentation
-- `#nid` to return the namespace identifier part of the `URN`.
+- `#nid` returns the namespace identifier part.
 ```ruby
-urn = URN('URN:NameSpace:Identifier')
-#=> "NameSpace"
+URN('URN:Name:Spec').nid
+#=> "Name"
 ```
-- `#nss` to return the namespace specific string part of the `URN`.
+- `#nss` returns the namespace specific string part.
 ```ruby
-urn = URN('URN:NameSpace:Identifier')
-#=> "Identifier"
+URN('URN:Name:Spec').nss
+#=> "Spec"
 ```
 
 ## [1.0.0] - 2016-03-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ URN('URN:Name:Spec').to_s
 - `#===(other)` returns true if the URN objects are equivalent. This method normalizes both URNs before doing the comparison, and allows comparison against Strings.
 - `#==(other)` returns true if the URN objects are equivalent. This method normalizes both URNs before doing the comparison.
 - `#eql?(other)` returns true if the URN objects are equal. This method does NOT normalize either URN before doing the comparison.
+- `.extract(str)` attempts to parse and merge a set of URNs. If no `block` is given, then returns the result as an `Array`. Else it calls `block` for each element in result and returns `nil`.
 
 ### Removed
 - `#valid?`. Validity check is now at object creation time, therefore all instances of `URN` are valid.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ URN('URN:Name:Spec').to_s
 - `#==(other)` returns true if the URN objects are equivalent. This method normalizes both URNs before doing the comparison.
 - `#eql?(other)` returns true if the URN objects are equal. This method does NOT normalize either URN before doing the comparison.
 - `.extract(str)` attempts to parse and merge a set of URNs. If no `block` is given, then returns the result as an `Array`. Else it calls `block` for each element in result and returns `nil`.
+- URN initialization accepts a `URN` as argument:
+```ruby
+URN(URN('urn:foo:bar'))
+#=> #<URN:0x007f85040434c8 @urn="urn:foo:bar">
+```
 
 ### Removed
 - `#valid?`. Validity check is now at object creation time, therefore all instances of `URN` are valid.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ urn = URN('URN:NameSpace:Identifier')
 #=> #<URN:0x007fd97a835558 @urn="URN:NameSpace:Identifier">
 ```
 - `REGEX` into the API documentation
+- `#nid` to return the namespace identifier part of the `URN`.
+```ruby
+urn = URN('URN:NameSpace:Identifier')
+#=> "NameSpace"
+```
+- `#nss` to return the namespace specific string part of the `URN`.
+```ruby
+urn = URN('URN:NameSpace:Identifier')
+#=> "Identifier"
+```
 
 ## [1.0.0] - 2016-03-09
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,9 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ## Current
 ### Changed
 - Only return `URN` instances for valid `URN`s at creation. Raise `URN::InvalidURNError` otherwise.
-- `#valid?` is deprecated and always return true
 - `#normalize` returns a normalized `URN` object instead of its `String` representation. You can get the normalized `String` representation with `.normalize.to_s`
 
-## Added
+### Added
 - Shortcut method (`URN()`) at creation:
 ```ruby
 urn = URN('URN:Name:Spec')
@@ -33,6 +32,10 @@ URN('URN:Name:Spec').to_s
 - `#===(other)` returns true if the URN objects are equivalent. This method normalizes both URNs before doing the comparison, and allows comparison against Strings.
 - `#==(other)` returns true if the URN objects are equivalent. This method normalizes both URNs before doing the comparison.
 - `#eql?(other)` returns true if the URN objects are equal. This method does NOT normalize either URN before doing the comparison.
+
+### Removed
+- `#valid?`. Validity check is now at object creation time, therefore all instances of `URN` are valid.
+
 
 ## [1.0.0] - 2016-03-09
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ URN('URN:Name:Spec').nid
 URN('URN:Name:Spec').nss
 #=> "Spec"
 ```
+- `#to_s` returns the `String` representation.
+```ruby
+URN('URN:Name:Spec').to_s
+#=> "URN:Name:Spec"
+```
 
 ## [1.0.0] - 2016-03-09
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Only return `URN` instances for valid `URN`s at creation. Raise `URN::InvalidURNError` otherwise.
 - `#normalize` returns a normalized `URN` object instead of its `String` representation. You can get the normalized `String` representation with `.normalize.to_s`
-- Do not allow hexadecimal numbers from 0 to 20. See [RFC2141](https://www.ietf.org/rfc/rfc2141.txt) section "2.4 Excluded characters".
+- Do not allow hexadecimal numbers from 0 to 20 and from 7F to FF. See [RFC2141](https://www.ietf.org/rfc/rfc2141.txt) section "2.4 Excluded characters".
 
 ### Added
 - Shortcut method (`URN()`) at creation:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
+## Current
+### Changed
+- Only return `URN` instances for valid `URN`s at creation. Raise `URN::InvalidURNError` otherwise.
+- `#valid?` is deprecated and always return true
+
+## Added
+- Shortcut method (`URN()`) at creation:
+```ruby
+urn = URN('URN:NameSpace:Identifier')
+#=> #<URN:0x007fd97a835558 @urn="URN:NameSpace:Identifier">
+```
+- `REGEX` into the API documentation
+
 ## [1.0.0] - 2016-03-09
 ### Changed
 - The library is now [RFC2141](https://www.ietf.org/rfc/rfc2141.txt) compliant.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Only return `URN` instances for valid `URN`s at creation. Raise `URN::InvalidURNError` otherwise.
 - `#valid?` is deprecated and always return true
+- `#normalize` returns a normalized `URN` object instead of its `String` representation. You can get the normalized `String` representation with `.normalize.to_s`
 
 ## Added
 - Shortcut method (`URN()`) at creation:

--- a/README.md
+++ b/README.md
@@ -41,25 +41,19 @@ urn = URN('123')
 ## API Documentation
 
 ### `URN::PATTERN`
-
 ```ruby
 text.match(/\?urn=(#{URN::PATTERN})/)
 ```
-
-Return a `String` of an unanchored regular expression suitable for matching
-URNs.
+Return a `String` of an unanchored regular expression suitable for matching URNs.
 
 ### `URN::REGEX`
-
 ```ruby
 URN::REGEX
 #=> /\A(?i:urn:(?!urn:)[a-z0-9][a-z0-9-]{1,31}:(?:[a-z0-9()+,-.:=@;$_!*']|%[0-9a-f]{2})+)\z/
 ```
-
 Return an `Regexp` object with the anchored regular expression suitable to match a URN.
 
 ### `URN()` or `URN.new`
-
 ```ruby
 urn = URN('urn:nid:nss')
 #=> #<URN:0xdecafbad @urn="urn:nid:nss">
@@ -67,39 +61,33 @@ urn = URN('urn:nid:nss')
 urn = URN.new('urn:nid:nss')
 #=> #<URN:0xdecafbad @urn="urn:nid:nss">
 
-urn = URN.new('1234')
+urn = URN('1234')
 #=> URN::InvalidURNError: bad URN(is not URN?): 1234
 ```
-
 Return a new `URN` instance when the given string is valid according to [RFC 2141](https://www.ietf.org/rfc/rfc2141.txt). Otherwise, it raises an `URN::InvalidURNError`
 
 ### `URN#normalize`
-
 ```ruby
-URN.new('URN:FOO:BAR').normalize
+URN('URN:FOO:BAR').normalize
 #=> "urn:foo:BAR"
 ```
-
 Return a normalized `String` representation of the `URN`, normalizing the case
 of the `urn` token and namespace identifier.
 
 ### `URN#nid`
-
 ```ruby
-URN.new('urn:nid:nss').nid
+URN('urn:nid:nss').nid
 #=> "nid"
 ```
-
-Return the namespace identifier part of the `URN`.
+Return the namespace identifier part.
 
 ### `URN#nss`
-
 ```ruby
-URN.new('urn:nid:nss').nss
+URN('urn:nid:nss').nss
 #=> "nss"
 ```
+Return the namespace specific string part.
 
-Return the namespace specific string for the `URN`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ Return a new `URN` instance when the given string is valid according to [RFC 214
 ### `URN#normalize`
 ```ruby
 URN('URN:FOO:BAR').normalize
-#=> "urn:foo:BAR"
+#=> #<URN:0x007fb9a3096848 @urn="urn:foo:BAR">
 ```
-Return a normalized `String` representation of the `URN`, normalizing the case
-of the `urn` token and namespace identifier.
+Return the normalized `URN` object, normalizing the case
+of the `urn` token and namespace identifier. Call `#to_s` after `#normalize` if you want the normalized `String` representation.
 
 ### `URN#nid`
 ```ruby

--- a/README.md
+++ b/README.md
@@ -95,6 +95,39 @@ URN('urn:Nid:Nss').to_s
 ```
 Return the `String` representation.
 
+### `#===(other)`
+```ruby
+URN('urn:name:spec') === 'URN:Name:spec'
+#=> true
+
+URN('urn:name:spec') === URN('URN:Name:spec')
+#=> true
+```
+Return true if the URN objects are equivalent. This method normalizes both URNs before doing the comparison, and allows comparison against Strings.
+
+### `#==(other)`
+```ruby
+URN('urn:name:spec') == 'URN:Name:spec'
+#=> false
+
+URN('urn:name:spec') == URN('URN:Name:spec')
+#=> true
+```
+Returns true if the URN objects are equivalent. This method normalizes both URNs before doing the comparison.
+
+### `#eql?(other)`
+```ruby
+URN('urn:name:spec').eql?('urn:name:spec')
+#=> false
+
+URN('urn:name:spec').eql?(URN('urn:NAME:spec'))
+#=> false
+
+URN('urn:name:spec').eql?(URN('urn:name:spec'))
+#=> true
+```
+Returns true if the URN objects are equal. This method does NOT normalize either URN before doing the comparison.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/altmetric/urn.

--- a/README.md
+++ b/README.md
@@ -25,14 +25,17 @@ Or install it yourself as:
 ## Usage
 
 ```ruby
+urn = URN('URN:NameSpace:Identifier')
+#=> #<URN:0x007fd97a835558 @urn="URN:NameSpace:Identifier">
+
 urn = URN.new('URN:NameSpace:Identifier')
 #=> #<URN:0x007fd97a835558 @urn="URN:NameSpace:Identifier">
 
-urn.valid?
-#=> true
-
 urn.normalize
 #=> "urn:namespace:Identifier"
+
+urn = URN('123')
+#=> URN::InvalidURNError: bad URN(is not URN?): 123
 ```
 
 ## API Documentation
@@ -46,26 +49,29 @@ text.match(/\?urn=(#{URN::PATTERN})/)
 Return a `String` of an unanchored regular expression suitable for matching
 URNs.
 
-### `URN.new`
+### `URN::REGEX`
 
 ```ruby
+URN::REGEX
+#=> /\A(?i:urn:(?!urn:)[a-z0-9][a-z0-9-]{1,31}:(?:[a-z0-9()+,-.:=@;$_!*']|%[0-9a-f]{2})+)\z/
+```
+
+Return an `Regexp` object with the anchored regular expression suitable to match a URN.
+
+### `URN()` or `URN.new`
+
+```ruby
+urn = URN('urn:nid:nss')
+#=> #<URN:0xdecafbad @urn="urn:nid:nss">
+
 urn = URN.new('urn:nid:nss')
 #=> #<URN:0xdecafbad @urn="urn:nid:nss">
+
+urn = URN.new('1234')
+#=> URN::InvalidURNError: bad URN(is not URN?): 1234
 ```
 
-Return a new `URN` instance with the given string.
-
-### `URN#valid?`
-
-```ruby
-URN.new('foo').valid?
-#=> false
-
-URN.new('urn:foo:bar').valid?
-#=> true
-```
-
-Returns true if the `URN` is valid according to [RFC 2141](https://www.ietf.org/rfc/rfc2141.txt).
+Return a new `URN` instance when the given string is valid according to [RFC 2141](https://www.ietf.org/rfc/rfc2141.txt). Otherwise, it raises an `URN::InvalidURNError`
 
 ### `URN#normalize`
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,20 @@ URN('urn:name:spec').eql?(URN('urn:name:spec'))
 ```
 Returns true if the URN objects are equal. This method does NOT normalize either URN before doing the comparison.
 
+### `.extract(str)`
+```ruby
+URN.extract('text urn:1234:abc more text URN:foo:bar%23.\\')
+#=> ['urn:1234:abc', 'URN:foo:bar%23.']
+
+normalized_urns = []
+#=> []
+URN.extract('text urn:1234:abc more text URN:foo:bar%23.\\') { |urn| normalized_urns << URN(urn).normalize.to_s }
+#=> nil
+normalized_urns
+#=> ['urn:1234:abc', 'URN:foo:bar%23.']
+```
+Extracts URNs from a string. If block given, iterates through all matched URNs. Returns nil if block given or array with matches.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/altmetric/urn.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Return a `String` of an unanchored regular expression suitable for matching URNs
 URN::REGEX
 #=> /\A(?i:urn:(?!urn:)[a-z0-9][a-z0-9-]{1,31}:(?:[a-z0-9()+,-.:=@;$_!*']|%[0-9a-f]{2})+)\z/
 ```
-Return an `Regexp` object with the anchored regular expression suitable to match a URN.
+Return a `Regexp` object with the anchored regular expression suitable to match a URN.
 
 ### `URN()` or `URN.new`
 ```ruby

--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ URN('urn:nid:nss').nss
 ```
 Return the namespace specific string part.
 
+### `URN#to_s`
+```ruby
+URN('urn:Nid:Nss').to_s
+#=> "urn:Nid:Nss"
+```
+Return the `String` representation.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,24 @@ URN.new('URN:FOO:BAR').normalize
 Return a normalized `String` representation of the `URN`, normalizing the case
 of the `urn` token and namespace identifier.
 
+### `URN#nid`
+
+```ruby
+URN.new('urn:nid:nss').nid
+#=> "nid"
+```
+
+Return the namespace identifier part of the `URN`.
+
+### `URN#nss`
+
+```ruby
+URN.new('urn:nid:nss').nss
+#=> "nss"
+```
+
+Return the namespace specific string for the `URN`.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/altmetric/urn.

--- a/lib/urn.rb
+++ b/lib/urn.rb
@@ -6,7 +6,7 @@ class URN
   InvalidURNError = Class.new(StandardError)
 
   PATTERN = %{(?i:urn:(?!urn:)[a-z0-9][a-z0-9\-]{1,31}:} +
-            %{(?:[a-z0-9()+,-.:=@;$_!*']|%(?:2[1-9a-f]|[3-9a-f][0-9a-f]))+)}.freeze
+            %{(?:[a-z0-9()+,-.:=@;$_!*']|%(?:2[1-9a-f]|[3-6][0-9a-f]|7[0-9a-e]))+)}.freeze
   REGEX = /\A#{PATTERN}\z/
 
   attr_reader :urn

--- a/lib/urn.rb
+++ b/lib/urn.rb
@@ -44,6 +44,10 @@ class URN
     "urn:#{normalized_nid}:#{normalized_nss}"
   end
 
+  def to_s
+    urn
+  end
+
   private
 
   def parse

--- a/lib/urn.rb
+++ b/lib/urn.rb
@@ -24,6 +24,7 @@ class URN
   end
 
   def initialize(urn)
+    urn = urn.to_s
     fail InvalidURNError, "bad URN(is not URN?): #{urn}" if urn !~ REGEX
 
     @urn = urn

--- a/lib/urn.rb
+++ b/lib/urn.rb
@@ -13,14 +13,9 @@ class URN
   private :urn
 
   def initialize(urn)
-    fail(InvalidURNError, "bad URN(is not URN?): #{urn}") if urn !~ REGEX
+    fail InvalidURNError, "bad URN(is not URN?): #{urn}" if urn !~ REGEX
 
     @urn = urn
-  end
-
-  def valid?
-    warn "[DEPRECATION] `valid?` is deprecated. Validity check is now at object creation."
-    true
   end
 
   def nid
@@ -39,7 +34,7 @@ class URN
     _scheme, nid, nss = parse
 
     normalized_nid = nid.downcase
-    normalized_nss = nss.gsub(/%([0-9a-f]{2})/i, &:downcase)
+    normalized_nss = nss.gsub(/%([0-9a-f]{2})/i) { |hex| hex.downcase }
 
     URN.new("urn:#{normalized_nid}:#{normalized_nss}")
   end

--- a/lib/urn.rb
+++ b/lib/urn.rb
@@ -12,15 +12,8 @@ class URN
   attr_reader :urn
   private :urn
 
-  def self.extract(str)
-    if block_given?
-      str.scan(/#{PATTERN}/) { yield $& }
-      nil
-    else
-      result = []
-      str.scan(/#{PATTERN}/) { result.push $& }
-      result
-    end
+  def self.extract(str, &blk)
+    str.scan(/#{PATTERN}/, &blk)
   end
 
   def initialize(urn)

--- a/lib/urn.rb
+++ b/lib/urn.rb
@@ -12,6 +12,17 @@ class URN
   attr_reader :urn
   private :urn
 
+  def self.extract(str)
+    if block_given?
+      str.scan(/#{PATTERN}/) { yield $& }
+      nil
+    else
+      result = []
+      str.scan(/#{PATTERN}/) { result.push $& }
+      result
+    end
+  end
+
   def initialize(urn)
     fail InvalidURNError, "bad URN(is not URN?): #{urn}" if urn !~ REGEX
 

--- a/lib/urn.rb
+++ b/lib/urn.rb
@@ -1,4 +1,10 @@
+def URN(urn)
+  URN.new(urn)
+end
+
 class URN
+  InvalidURNError = Class.new(StandardError)
+
   PATTERN = %{(?i:urn:(?!urn:)[a-z0-9][a-z0-9\-]{1,31}:} +
             %{(?:[a-z0-9()+,-.:=@;$_!*']|%[0-9a-f]{2})+)}.freeze
   REGEX = /\A#{PATTERN}\z/
@@ -7,19 +13,20 @@ class URN
   private :urn
 
   def initialize(urn)
+    fail(InvalidURNError, "bad URN(is not URN?): #{urn}") if urn !~ REGEX
+
     @urn = urn
   end
 
   def valid?
-    !(urn =~ REGEX).nil?
+    warn "[DEPRECATION] `valid?` is deprecated. Validity check is now at object creation."
+    true
   end
 
   def normalize
-    return unless valid?
-
     _scheme, nid, nss = urn.split(':', 3)
     normalized_nid = nid.downcase
-    normalized_nss = nss.gsub(/%([0-9a-f]{2})/i) { |hex| hex.downcase }
+    normalized_nss = nss.gsub(/%([0-9a-f]{2})/i, &:downcase)
 
     "urn:#{normalized_nid}:#{normalized_nss}"
   end

--- a/lib/urn.rb
+++ b/lib/urn.rb
@@ -41,7 +41,7 @@ class URN
     normalized_nid = nid.downcase
     normalized_nss = nss.gsub(/%([0-9a-f]{2})/i, &:downcase)
 
-    "urn:#{normalized_nid}:#{normalized_nss}"
+    URN.new("urn:#{normalized_nid}:#{normalized_nss}")
   end
 
   def to_s

--- a/lib/urn.rb
+++ b/lib/urn.rb
@@ -9,7 +9,7 @@ class URN
             %{(?:[a-z0-9()+,-.:=@;$_!*']|%(?:2[1-9a-f]|[3-6][0-9a-f]|7[0-9a-e]))+)}.freeze
   REGEX = /\A#{PATTERN}\z/
 
-  attr_reader :urn
+  attr_reader :urn, :nid, :nss
   private :urn
 
   def self.extract(str, &blk)
@@ -21,23 +21,10 @@ class URN
     fail InvalidURNError, "bad URN(is not URN?): #{urn}" if urn !~ REGEX
 
     @urn = urn
-  end
-
-  def nid
-    _scheme, nid, _nss = parse
-
-    nid
-  end
-
-  def nss
-    _scheme, _nid, nss = parse
-
-    nss
+    _scheme, @nid, @nss = urn.split(':', 3)
   end
 
   def normalize
-    _scheme, nid, nss = parse
-
     normalized_nid = nid.downcase
     normalized_nss = nss.gsub(/%([0-9a-f]{2})/i) { |hex| hex.downcase }
 
@@ -72,11 +59,5 @@ class URN
     return false unless other.is_a?(URN)
 
     to_s == other.to_s
-  end
-
-  private
-
-  def parse
-    urn.split(':', 3)
   end
 end

--- a/lib/urn.rb
+++ b/lib/urn.rb
@@ -48,6 +48,32 @@ class URN
     urn
   end
 
+  def ===(other)
+    if other.respond_to?(:normalize)
+      urn_string = other.normalize.to_s
+    else
+      begin
+        urn_string = URN.new(other).normalize.to_s
+      rescue URN::InvalidURNError
+        return false
+      end
+    end
+
+    normalize.to_s == urn_string
+  end
+
+  def ==(other)
+    return false unless other.is_a?(URN)
+
+    normalize.to_s == other.normalize.to_s
+  end
+
+  def eql?(other)
+    return false unless other.is_a?(URN)
+
+    to_s == other.to_s
+  end
+
   private
 
   def parse

--- a/lib/urn.rb
+++ b/lib/urn.rb
@@ -6,7 +6,7 @@ class URN
   InvalidURNError = Class.new(StandardError)
 
   PATTERN = %{(?i:urn:(?!urn:)[a-z0-9][a-z0-9\-]{1,31}:} +
-            %{(?:[a-z0-9()+,-.:=@;$_!*']|%[0-9a-f]{2})+)}.freeze
+            %{(?:[a-z0-9()+,-.:=@;$_!*']|%(?:2[1-9a-f]|[3-9a-f][0-9a-f]))+)}.freeze
   REGEX = /\A#{PATTERN}\z/
 
   attr_reader :urn

--- a/lib/urn.rb
+++ b/lib/urn.rb
@@ -23,11 +23,30 @@ class URN
     true
   end
 
+  def nid
+    _scheme, nid, _nss = parse
+
+    nid
+  end
+
+  def nss
+    _scheme, _nid, nss = parse
+
+    nss
+  end
+
   def normalize
-    _scheme, nid, nss = urn.split(':', 3)
+    _scheme, nid, nss = parse
+
     normalized_nid = nid.downcase
     normalized_nss = nss.gsub(/%([0-9a-f]{2})/i, &:downcase)
 
     "urn:#{normalized_nid}:#{normalized_nss}"
+  end
+
+  private
+
+  def parse
+    urn.split(':', 3)
   end
 end

--- a/spec/urn_spec.rb
+++ b/spec/urn_spec.rb
@@ -137,4 +137,21 @@ RSpec.describe URN do
       expect(described_class.new('urn:name:spec')).not_to eql(described_class.new('urn:Name:spec'))
     end
   end
+
+  describe '.extract' do
+    it 'extracts the URNs from a string' do
+      str = 'En un pueblo italiano urn:1234:abc al pie de la montaña URN:foo:bar%23.\\'
+
+      expect(URN.extract(str)).to contain_exactly('urn:1234:abc', 'URN:foo:bar%23.')
+    end
+
+    it 'extracts the URNs from a string using a block' do
+      str = 'Llum, foc, destrucció. urn:foo:%10 El món pot ser només una runa, URN:FOO:BA%2cR això no ho consentirem.'
+
+      normalized_urns = []
+      URN.extract(str) { |urn| normalized_urns << URN(urn).normalize.to_s }
+
+      expect(normalized_urns).to contain_exactly('urn:foo:BA%2cR')
+    end
+  end
 end

--- a/spec/urn_spec.rb
+++ b/spec/urn_spec.rb
@@ -85,4 +85,10 @@ RSpec.describe URN do
       expect(described_class.new('urn:namespace:specificstring').nss).to eq('specificstring')
     end
   end
+
+  describe '#to_s' do
+    it 'returns the string representation of the URN' do
+      expect(described_class.new('urn:Name:Spec').to_s).to eq('urn:Name:Spec')
+    end
+  end
 end

--- a/spec/urn_spec.rb
+++ b/spec/urn_spec.rb
@@ -91,4 +91,46 @@ RSpec.describe URN do
       expect(described_class.new('urn:Name:Spec').to_s).to eq('urn:Name:Spec')
     end
   end
+
+  describe '#===' do
+    it 'returns true if the string is an equivalent valid URN' do
+      expect(described_class.new('urn:name:spec') === 'URN:Name:spec').to be(true)
+    end
+
+    it 'returns true if the normalized object of the other class is equal' do
+      expect(described_class.new('urn:name:spec') === URI('urn:name:spec')).to be(true)
+    end
+
+    it 'returns true if the URN object is an equivalent valid URN' do
+      expect(described_class.new('urn:name:spec') === described_class.new('URN:Name:spec')).to be(true)
+    end
+
+    it 'returns false if the URN is not equivalent' do
+      expect(described_class.new('urn:name:spec') === described_class.new('URN:Name:SPEC')).to be(false)
+    end
+
+    it 'return false if the URN is not valid' do
+      expect(described_class.new('urn:name:spec') === 'urn:urn:urn').to be(false)
+    end
+  end
+
+  describe '#==' do
+    it 'returns true if the URN object is an equivalent valid URN' do
+      expect(described_class.new('urn:name:spec')).to eq(described_class.new('URN:Name:spec'))
+    end
+
+    it 'returns false if the argument is not a URN object' do
+      expect(described_class.new('urn:name:spec')).not_to eq('urn:name:spec')
+    end
+  end
+
+  describe '#eql?' do
+    it 'returns true if both URNs are equal' do
+      expect(described_class.new('urn:Name:Spec')).to eql(described_class.new('urn:Name:Spec'))
+    end
+
+    it 'returns false if the URNs are not equal' do
+      expect(described_class.new('urn:name:spec')).not_to eql(described_class.new('urn:Name:spec'))
+    end
+  end
 end

--- a/spec/urn_spec.rb
+++ b/spec/urn_spec.rb
@@ -2,51 +2,61 @@
 require 'urn'
 
 RSpec.describe URN do
-  describe '#valid?' do
-    it 'returns true if it is valid' do
-      expect(described_class.new('urn:namespace:specificstring')).to be_valid
+  describe 'Kernel.URN' do
+    it 'returns a URN if it is valid' do
+      expect(URN('urn:namespace:specificstring')).to be_kind_of(described_class)
     end
 
-    it 'returns true if namespace includes urn' do
-      expect(described_class.new('urn:urnnamespace:specificstring')).to be_valid
+    it 'raise InvalidURNError if it is not valid' do
+      expect { URN('urn:urn:1234') }.to raise_error(described_class::InvalidURNError, 'bad URN(is not URN?): urn:urn:1234')
+    end
+  end
+
+  describe '#initialize' do
+    it 'returns a URN if it is valid' do
+      expect(described_class.new('urn:namespace:specificstring')).to be_kind_of(described_class)
     end
 
-    it 'returns false if it does not start with urn' do
-      expect(described_class.new('not-urn:namespace:specificstring')).not_to be_valid
+    it 'raise InvalidURNError if it is not valid' do
+      expect { described_class.new('urn:urn:1234') }.to raise_error(described_class::InvalidURNError, 'bad URN(is not URN?): urn:urn:1234')
     end
 
-    it 'returns false if namespace is urn' do
-      expect(described_class.new('urn:urn:specificstring')).not_to be_valid
+    it 'returns a URN if namespace includes urn' do
+      expect(described_class.new('urn:urnnamespace:specificstring')).to be_kind_of(described_class)
     end
 
-    it 'returns false if namespace is URN' do
-      expect(described_class.new('urn:URN:specificstring')).not_to be_valid
+    it 'returns error if it does not start with urn' do
+      expect { described_class.new('not-urn:namespace:specificstring') }.to raise_error(described_class::InvalidURNError)
+    end
+
+    it 'returns error if namespace is urn' do
+      expect { described_class.new('urn:urn:specificstring') }.to raise_error(described_class::InvalidURNError)
+    end
+
+    it 'returns error if namespace is URN' do
+      expect { described_class.new('urn:URN:specificstring') }.to raise_error(described_class::InvalidURNError)
     end
 
     it 'returns true if the namespace identifier is 32 characters long' do
       nid = 'a' * 32
 
-      expect(described_class.new("urn:#{nid}:bar")).to be_valid
+      expect(described_class.new("urn:#{nid}:bar")).to be_kind_of(described_class)
     end
 
-    it 'returns false if the namespace identifier begins with a hyphen' do
-      expect(described_class.new('urn:-foo:bar')).not_to be_valid
+    it 'returns error if the namespace identifier begins with a hyphen' do
+      expect { described_class.new('urn:-foo:bar') }.to raise_error(described_class::InvalidURNError)
     end
 
-    it 'returns false if the namespace specific string has invalid escaping' do
-      expect(described_class.new('urn:foo:bar%2')).not_to be_valid
+    it 'returns error if the namespace specific string has invalid escaping' do
+      expect { described_class.new('urn:foo:bar%2') }.to raise_error(described_class::InvalidURNError)
     end
 
-    it 'returns false if the namespace specific string has reserved characters' do
-      expect(described_class.new('urn:foo:café')).not_to be_valid
+    it 'returns error if the namespace specific string has reserved characters' do
+      expect { described_class.new('urn:foo:café') }.to raise_error(described_class::InvalidURNError)
     end
   end
 
   describe '#normalize' do
-    it 'returns nil if it is not valid' do
-      expect(described_class.new('urn:').normalize).to be_nil
-    end
-
     it 'lowercases the leading "urn:" token' do
       expect(described_class.new('URN:foo:123').normalize).to eq('urn:foo:123')
     end

--- a/spec/urn_spec.rb
+++ b/spec/urn_spec.rb
@@ -10,9 +10,21 @@ RSpec.describe URN do
     it 'raise InvalidURNError if it is not valid' do
       expect { URN('urn:urn:1234') }.to raise_error(described_class::InvalidURNError, 'bad URN(is not URN?): urn:urn:1234')
     end
+
+    it 'returns the same URN if the argument is a URN' do
+      urn = URN.new('urn:foo:bar')
+
+      expect(URN(urn).to_s).to eq('urn:foo:bar')
+    end
   end
 
   describe '#initialize' do
+    it 'returns the same URN if the argument is a URN' do
+      urn = URN.new('urn:foo:bar')
+
+      expect(URN.new(urn).to_s).to eq('urn:foo:bar')
+    end
+
     it 'returns a URN if it is valid' do
       expect(described_class.new('urn:namespace:specificstring')).to be_kind_of(described_class)
     end

--- a/spec/urn_spec.rb
+++ b/spec/urn_spec.rb
@@ -58,19 +58,19 @@ RSpec.describe URN do
 
   describe '#normalize' do
     it 'lowercases the leading "urn:" token' do
-      expect(described_class.new('URN:foo:123').normalize).to eq('urn:foo:123')
+      expect(described_class.new('URN:foo:123').normalize.to_s).to eq('urn:foo:123')
     end
 
     it 'lowercases the namespace identifier' do
-      expect(described_class.new('urn:FOO:123').normalize).to eq('urn:foo:123')
+      expect(described_class.new('urn:FOO:123').normalize.to_s).to eq('urn:foo:123')
     end
 
     it 'lowercases %-escaping in the namespace specific string' do
-      expect(described_class.new('urn:foo:123%2C456').normalize).to eq('urn:foo:123%2c456')
+      expect(described_class.new('urn:foo:123%2C456').normalize.to_s).to eq('urn:foo:123%2c456')
     end
 
     it 'does not lowercase other characters in the namespace specific string' do
-      expect(described_class.new('urn:foo:BA%2CR').normalize).to eq('urn:foo:BA%2cR')
+      expect(described_class.new('urn:foo:BA%2CR').normalize.to_s).to eq('urn:foo:BA%2cR')
     end
   end
 

--- a/spec/urn_spec.rb
+++ b/spec/urn_spec.rb
@@ -54,6 +54,10 @@ RSpec.describe URN do
     it 'raises an error if the namespace specific string has reserved characters' do
       expect { described_class.new('urn:foo:café') }.to raise_error(described_class::InvalidURNError)
     end
+
+    it 'raises an error if the namespace specific string has a not allowed hexadecimal value' do
+      expect { described_class.new('urn:foo:abc%10') }.to raise_error(described_class::InvalidURNError)
+    end
   end
 
   describe '#normalize' do

--- a/spec/urn_spec.rb
+++ b/spec/urn_spec.rb
@@ -73,4 +73,16 @@ RSpec.describe URN do
       expect(described_class.new('urn:foo:BA%2CR').normalize).to eq('urn:foo:BA%2cR')
     end
   end
+
+  describe '#nid' do
+    it 'returns the namespace identifier' do
+      expect(described_class.new('urn:namespace:specificstring').nid).to eq('namespace')
+    end
+  end
+
+  describe '#nss' do
+    it 'returns the namespace specific string' do
+      expect(described_class.new('urn:namespace:specificstring').nss).to eq('specificstring')
+    end
+  end
 end

--- a/spec/urn_spec.rb
+++ b/spec/urn_spec.rb
@@ -2,7 +2,7 @@
 require 'urn'
 
 RSpec.describe URN do
-  describe 'Kernel.URN' do
+  describe 'URN' do
     it 'returns a URN if it is valid' do
       expect(URN('urn:namespace:specificstring')).to be_kind_of(described_class)
     end
@@ -25,15 +25,15 @@ RSpec.describe URN do
       expect(described_class.new('urn:urnnamespace:specificstring')).to be_kind_of(described_class)
     end
 
-    it 'returns error if it does not start with urn' do
+    it 'raises an error if it does not start with urn' do
       expect { described_class.new('not-urn:namespace:specificstring') }.to raise_error(described_class::InvalidURNError)
     end
 
-    it 'returns error if namespace is urn' do
+    it 'raises an error if namespace is urn' do
       expect { described_class.new('urn:urn:specificstring') }.to raise_error(described_class::InvalidURNError)
     end
 
-    it 'returns error if namespace is URN' do
+    it 'raises an error if namespace is URN' do
       expect { described_class.new('urn:URN:specificstring') }.to raise_error(described_class::InvalidURNError)
     end
 
@@ -43,15 +43,15 @@ RSpec.describe URN do
       expect(described_class.new("urn:#{nid}:bar")).to be_kind_of(described_class)
     end
 
-    it 'returns error if the namespace identifier begins with a hyphen' do
+    it 'raises an error if the namespace identifier begins with a hyphen' do
       expect { described_class.new('urn:-foo:bar') }.to raise_error(described_class::InvalidURNError)
     end
 
-    it 'returns error if the namespace specific string has invalid escaping' do
+    it 'raises an error if the namespace specific string has invalid escaping' do
       expect { described_class.new('urn:foo:bar%2') }.to raise_error(described_class::InvalidURNError)
     end
 
-    it 'returns error if the namespace specific string has reserved characters' do
+    it 'raises an error if the namespace specific string has reserved characters' do
       expect { described_class.new('urn:foo:café') }.to raise_error(described_class::InvalidURNError)
     end
   end


### PR DESCRIPTION
Fixes #2

**Note**: These are the changes planned for the 2.0, which I'd like to release this Monday 21st March 2016.
### Changed
- Only return `URN` instances for valid `URN`s at creation. Raise `URN::InvalidURNError` otherwise.
- `#normalize` returns a normalized `URN` object instead of its `String` representation. You can get the normalized `String` representation with `.normalize.to_s`
- Do not allow hexadecimal numbers from 0 to 20 and from 7F to FF. See [RFC2141](https://www.ietf.org/rfc/rfc2141.txt) section "2.4 Excluded characters".
### Added
- Shortcut method (`URN()`) at creation:

``` ruby
urn = URN('URN:Name:Spec')
#=> #<URN:0x007fd97a835558 @urn="URN:Name:Spec">
```
- `REGEX` into the API documentation
- `#nid` returns the namespace identifier part.

``` ruby
URN('URN:Name:Spec').nid
#=> "Name"
```
- `#nss` returns the namespace specific string part.

``` ruby
URN('URN:Name:Spec').nss
#=> "Spec"
```
- `#to_s` returns the `String` representation.

``` ruby
URN('URN:Name:Spec').to_s
#=> "URN:Name:Spec"
```
- `#===(other)` returns true if the URN objects are equivalent. This method normalizes both URNs before doing the comparison, and allows comparison against Strings.
- `#==(other)` returns true if the URN objects are equivalent. This method normalizes both URNs before doing the comparison.
- `#eql?(other)` returns true if the URN objects are equal. This method does NOT normalize either URN before doing the comparison.
- `.extract(str)` attempts to parse and merge a set of URNs. If no `block` is given, then returns the result as an `Array`. Else it calls `block` for each element in result and returns `nil`.
### Removed
- `#valid?`. Validity check is now at object creation time, therefore all instances of `URN` are valid.
