### PR TITLE
Allow slash char on NSS

### DIFF
--- a/lib/urn.rb
+++ b/lib/urn.rb
@@ -7,7 +7,7 @@ end
 class URN
   InvalidURNError = Class.new(StandardError)
 
-  PATTERN = %{(?i:urn:(?!urn:)[a-z0-9][a-z0-9\-]{1,31}:} +
+  PATTERN = %{(?i:urn:(?!urn:)[a-z0-9][\x00-\x7F]{1,31}:} +
             %{(?:[a-z0-9()+,-.:=@;$_!*'/]|%(?:2[1-9a-f]|[3-6][0-9a-f]|7[0-9a-e]))+)}.freeze
   REGEX = /\A#{PATTERN}\z/
 

--- a/lib/urn.rb
+++ b/lib/urn.rb
@@ -8,7 +8,7 @@ class URN
   InvalidURNError = Class.new(StandardError)
 
   PATTERN = %{(?i:urn:(?!urn:)[a-z0-9][a-z0-9\-]{1,31}:} +
-            %{(?:[a-z0-9()+,-.:=@;$_!*']|%(?:2[1-9a-f]|[3-6][0-9a-f]|7[0-9a-e]))+)}.freeze
+            %{(?:[a-z0-9()+,-.:=@;$_!*'/]|%(?:2[1-9a-f]|[3-6][0-9a-f]|7[0-9a-e]))+)}.freeze
   REGEX = /\A#{PATTERN}\z/
 
   attr_reader :urn, :nid, :nss

--- a/spec/urn_spec.rb
+++ b/spec/urn_spec.rb
@@ -29,6 +29,10 @@ RSpec.describe URN do
       expect(described_class.new('urn:namespace:specificstring')).to be_kind_of(described_class)
     end
 
+    it 'returns a URN if NSS includes /' do
+      expect(described_class.new('urn:namespace:specificstring/withbar')).to be_kind_of(described_class)
+    end
+
     it 'raise InvalidURNError if it is not valid' do
       expect { described_class.new('urn:urn:1234') }.to raise_error(described_class::InvalidURNError, 'bad URN(is not URN?): urn:urn:1234')
     end

--- a/spec/urn_spec.rb
+++ b/spec/urn_spec.rb
@@ -33,6 +33,10 @@ RSpec.describe URN do
       expect(described_class.new('urn:namespace:specificstring/withbar')).to be_kind_of(described_class)
     end
 
+    it 'returns a URN if NID includes ascii chars' do
+      expect(described_class.new('urn:namespace.,:specificstring/withbar')).to be_kind_of(described_class)
+    end
+
     it 'raise InvalidURNError if it is not valid' do
       expect { described_class.new('urn:urn:1234') }.to raise_error(described_class::InvalidURNError, 'bad URN(is not URN?): urn:urn:1234')
     end


### PR DESCRIPTION
This change is to reflect some of the changes made to the URN syntax on
rfc8141